### PR TITLE
Serve everything through the webserver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-default: flashcards.html
+default: build run
 
 flashcards_out.md: browse.py
 	python browse.py > flashcards_out.md
@@ -12,5 +12,7 @@ clean:
 	rm -f flashcards.html
 	rm -f flashcards_out.md
 
-record:
+run:
 	export FLASK_APP=flaskstuff.py; python -m flask run
+
+build: flashcards.html

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ flashcards_out.md: browse.py
 	python browse.py > flashcards_out.md
 
 flashcards.html:flashcards_out.md
-	pandoc -t revealjs -s -o flashcards.html flashcards_out.md --slide-level=2
+	pandoc -t revealjs -V revealjs-url=http://lab.hakim.se/reveal-js -s -o flashcards.html flashcards_out.md --slide-level=2
 	rm flashcards_out.md
 
 clean:

--- a/README.md
+++ b/README.md
@@ -9,15 +9,8 @@ This program generates a random reveal.js slideshow from given flashcards, it re
 
 ## Installation.
 
-1. Put reveal.js in the correct place:
-```bash
-wget https://github.com/hakimel/reveal.js/archive/master.tar.gz
-tar -xzvf master.tar.gz
-mv reveal.js-master reveal.js
-```
+1. Write your flashcards in `flashcards.md`, there are examples in there. Each heading is translated to a flashcard, subheadings can be used to categorise each card.
 
-2. Write your flashcards in `flashcards.md`, there are examples in there. Each heading is translated to a flashcard, subheadings can be used to categorise each card.
+2. Run `make` to produce flashcards.html, which you can open in your web browser.
 
-3. Run `make` to produce flashcards.html, which you can open in your web browser.
-
-4. To record whether you 'got it', you must also run `make record` in the background while you are reading your flashcards.
+3. To record whether you 'got it', you must also run `make record` in the background while you are reading your flashcards.

--- a/flaskstuff.py
+++ b/flaskstuff.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, send_file
+from flask import Flask, request, send_file, render_template
 from csv import reader, writer
 import os.path
 app = Flask(__name__)
@@ -8,7 +8,7 @@ def index():
     if os.path.isfile('flashcards.html'):
         return send_file('flashcards.html')
     else:
-        return "not found"
+        return render_template('404.html'), 404
 
 
 @app.route("/data", methods=['POST'])

--- a/flaskstuff.py
+++ b/flaskstuff.py
@@ -1,7 +1,15 @@
-from flask import Flask, request
+from flask import Flask, request, send_file
 from csv import reader, writer
 import os.path
 app = Flask(__name__)
+
+@app.route("/", methods=['GET'])
+def index():
+    if os.path.isfile('flashcards.html'):
+        return send_file('flashcards.html')
+    else:
+        return "not found"
+
 
 @app.route("/data", methods=['POST'])
 def hello():

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,10 @@
+<html>
+	<head>
+		<title>Page Not Found</title>
+	</head>
+	<body>
+		<h1>Page Not Found</h1>
+		<p>What you were looking for is just not there. Maybe try running make first.</p>
+		<p><a href="{{ url_for('index') }}">Try again</a></p>
+	</body>
+</html>


### PR DESCRIPTION
* Webserver serves flashcards.html on the root route
* Makefile builds and starts the server separately, but by default will do both (ensures that card ordering updates)
* reveal.js grabbed from the internet instead of locally. This will break same origin policy if just opening the html file, but could just remove the pandoc flag and install locally like before
* Updated readme to reflect reveal.js change